### PR TITLE
Typo fix in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -245,7 +245,7 @@ OpenWhisk apply.
 All app activations are asynchronous and non-blocking. The immediate
 result of an invocation is a _session id_, which you may use to query
 the app for its final output. For development convenience, the shell
-implements a client-side poll to provide a the final output of the
+implements a client-side poll to provide the final output of the
 app, if it is ready within 30 seconds. Otherwise, you may use the
 session id to retrieve the output; in this way, working with a session
 id is similar to working with an activation id when invoking an


### PR DESCRIPTION
Not sure if you want `a` or `the`, but `the` sounds a little bit better, at least to me.

Can change it to `a` if you want.