### PR TITLE
Add IAM token expiration check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
     - __OW_IGNORE_CERTS=true
     - REDIS=redis://172.17.0.1:6379
     - IC_FN_CONFIG_FILE=./test/cf-plugin-config.json
+    - IC_CONFIG_FILE=./test/cf-config.json
 before_install:
   - ./travis/scancode.sh
 before_script:

--- a/client.js
+++ b/client.js
@@ -76,6 +76,16 @@ module.exports = function (options, basic, bearer) {
   //
   // check for IAM-based namespaces, first
   if (namespaceType === NS_TYPE_IAM) {
+    const tokenTimestamp = ibmcloudUtils.getIamTokenTimestamp()
+
+    if (ibmcloudUtils.iamTokenExpired(tokenTimestamp)) {
+        console.log(
+            'Error: Your IAM token seems to be expired. Plase perform an `ibmcloud login` ' +
+            'to make sure your token is up to date.'
+        )
+        throw new Error(`IAM token expired`)
+    }
+
     // for authentication, we'll use the user IAM access token
     const iamToken = ibmcloudUtils.getIamAuthHeader()
 

--- a/client.js
+++ b/client.js
@@ -79,11 +79,11 @@ module.exports = function (options, basic, bearer) {
     const tokenTimestamp = ibmcloudUtils.getIamTokenTimestamp()
 
     if (ibmcloudUtils.iamTokenExpired(tokenTimestamp)) {
-        console.log(
-            'Error: Your IAM token seems to be expired. Plase perform an `ibmcloud login` ' +
+      console.log(
+        'Error: Your IAM token seems to be expired. Plase perform an `ibmcloud login` ' +
             'to make sure your token is up to date.'
-        )
-        throw new Error(`IAM token expired`)
+      )
+      throw new Error('IAM token expired')
     }
 
     // for authentication, we'll use the user IAM access token

--- a/ibmcloud-utils.js
+++ b/ibmcloud-utils.js
@@ -68,17 +68,17 @@ const getIamAuthHeader = () => {
 }
 
 const getIamTokenTimestamp = () => {
-   const timestamp = getCloudFunctionsConfig().IamTimeTokenRefreshed
-   return new Date(timestamp)
+  const timestamp = getCloudFunctionsConfig().IamTimeTokenRefreshed
+  return new Date(timestamp)
 }
 
 const iamTokenExpired = (timeRefreshed, timeReference) => {
-    if (typeof(timeReference) === 'undefined') {
-        timeReference = new Date()
-    }
+  if (typeof (timeReference) === 'undefined') {
+    timeReference = new Date()
+  }
 
-    // time difference in hours exceeds 1 hour
-    return (timeReference - timeRefreshed) / 1000 / 3600 > 1
+  // time difference in hours exceeds 1 hour
+  return (timeReference - timeRefreshed) / 1000 / 3600 > 1
 }
 
 module.exports = {

--- a/ibmcloud-utils.js
+++ b/ibmcloud-utils.js
@@ -67,8 +67,24 @@ const getIamAuthHeader = () => {
   return iamToken
 }
 
+const getIamTokenTimestamp = () => {
+   const timestamp = getCloudFunctionsConfig().IamTimeTokenRefreshed
+   return new Date(timestamp)
+}
+
+const iamTokenExpired = (timeRefreshed, timeReference) => {
+    if (typeof(timeReference) === 'undefined') {
+        timeReference = new Date()
+    }
+
+    // time difference in hours exceeds 1 hour
+    return (timeReference - timeRefreshed) / 1000 / 3600 > 1
+}
+
 module.exports = {
+  iamTokenExpired,
   getIamAuthHeader,
-  getNamespaceType,
-  getNamespaceId
+  getIamTokenTimestamp,
+  getNamespaceId,
+  getNamespaceType
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "mocha": "^5.2.0",
+    "mock-fs": "^4.13.0",
     "pre-commit": "^1.2.2",
     "standard": "^12.0.1"
   },

--- a/test/ibmcloud-utils.js
+++ b/test/ibmcloud-utils.js
@@ -21,8 +21,6 @@
 
 const assert = require('assert')
 const mock = require('mock-fs')
-const os = require('os')
-const path = require('path')
 
 const ibmcloudUtils = require('../ibmcloud-utils')
 const client = require('../client')
@@ -31,9 +29,7 @@ describe('ibmcloud-utils', function () {
   describe('ibmcloud-utils.token-expiration', function () {
     it('read timestamp', function () {
       mock({
-        [path.join(os.homedir(), '.bluemix/plugins/cloud-functions')]: {
-          'config.json': '{ "IamTimeTokenRefreshed": "2021-03-15T13:24:14+01:00" }'
-        }
+        'test/cf-plugin-config.json': '{ "IamTimeTokenRefreshed": "2021-03-15T13:24:14+01:00" }'
       })
       const timestamp = ibmcloudUtils.getIamTokenTimestamp()
       assert.strictEqual(timestamp.getTime(), new Date(2021, 2, 15, 13, 24, 14).getTime())
@@ -55,16 +51,10 @@ describe('ibmcloud-utils', function () {
 
     it('client fails when token expired', function () {
       mock({
-        [path.join(os.homedir(), '.bluemix')]: {
-          'config.json': '{ "IAMToken": "some-token" }',
-          'plugins': {
-            'cloud-functions': {
-              'config.json': '{ "IamTimeTokenRefreshed": "2021-03-14T12:00:00+01:00", ' +
-                        '"WskCliNamespaceId": "some-namespace-id", ' +
-                        '"WskCliNamespaceMode": "IAM" }'
-            }
-          }
-        }
+        'test/cf-plugin-config.json': '{ "IamTimeTokenRefreshed": "2021-03-14T12:00:00+01:00", ' +
+            '"WskCliNamespaceId": "some-namespace-id", ' +
+            '"WskCliNamespaceMode": "IAM" }',
+        'test/cf-config.json': '{ "IAMToken": "some-token" }'
       })
 
       assert.throws(() => client(), /IAM token expired/)

--- a/test/ibmcloud-utils.js
+++ b/test/ibmcloud-utils.js
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+'use strict'
+
+const assert = require('assert')
+const mock = require('mock-fs')
+const os = require('os')
+const path = require('path')
+
+const ibmcloudUtils = require('../ibmcloud-utils')
+const client = require('../client')
+
+describe('ibmcloud-utils', function () {
+  describe('ibmcloud-utils.token-expiration', function () {
+    it('read timestamp', function () {
+        mock({
+            [path.join(os.homedir(), '.bluemix/plugins/cloud-functions')]: {
+                'config.json': '{ "IamTimeTokenRefreshed": "2021-03-15T13:24:14+01:00" }'
+            }
+        })
+        const timestamp = ibmcloudUtils.getIamTokenTimestamp()
+        assert.equal(timestamp.getTime(), new Date(2021, 2, 15, 13, 24, 14).getTime())
+    })
+
+    it('token not expired', function() {
+        const timeRefreshed = new Date(2021, 2, 13, 13, 24, 14)
+        const timeReference = new Date(2021, 2, 13, 13, 30, 0)
+        const tokenExpired = ibmcloudUtils.iamTokenExpired(timeRefreshed, timeReference)
+        assert.equal(tokenExpired, false)
+    })
+
+    it('token expired', function() {
+        const timeRefreshed = new Date(2021, 2, 13, 13, 24, 14)
+        const timeReference = new Date(2021, 2, 13, 14, 25, 0)
+        const tokenExpired = ibmcloudUtils.iamTokenExpired(timeRefreshed, timeReference)
+        assert.equal(tokenExpired, true)
+    })
+
+    it('client fails when token expired', function() {
+        mock({
+            [path.join(os.homedir(), '.bluemix')]: {
+                'config.json': '{ "IAMToken": "some-token" }',
+                'plugins': {
+                    'cloud-functions': {
+                        'config.json': '{ "IamTimeTokenRefreshed": "2021-03-14T12:00:00+01:00", '
+                        + '"WskCliNamespaceId": "some-namespace-id", '
+                        + '"WskCliNamespaceMode": "IAM" }'
+                    }
+                }
+            }
+        })
+
+        assert.throws(() => client(), /IAM token expired/)
+    })
+  })
+})

--- a/test/ibmcloud-utils.js
+++ b/test/ibmcloud-utils.js
@@ -21,15 +21,21 @@
 
 const assert = require('assert')
 const mock = require('mock-fs')
+const path = require('path')
+const os = require('os')
 
 const ibmcloudUtils = require('../ibmcloud-utils')
 const client = require('../client')
 
 describe('ibmcloud-utils', function () {
   describe('ibmcloud-utils.token-expiration', function () {
+    const ibmCloudFunctionsPropsPath =
+      process.env.IC_FN_CONFIG_FILE || path.join(os.homedir(), '.bluemix/plugins/cloud-functions/config.json')
+    const ibmCloudPropsPath = process.env.IC_CONFIG_FILE || path.join(os.homedir(), '.bluemix/config.json')
+
     it('read timestamp', function () {
       mock({
-        'test/cf-plugin-config.json': '{ "IamTimeTokenRefreshed": "2021-03-15T13:24:14+01:00" }'
+        [ibmCloudFunctionsPropsPath]: '{ "IamTimeTokenRefreshed": "2021-03-15T13:24:14+01:00" }'
       })
       const timestamp = ibmcloudUtils.getIamTokenTimestamp()
       assert.strictEqual(timestamp.getTime(), Date.UTC(2021, 2, 15, 12, 24, 14))
@@ -51,10 +57,10 @@ describe('ibmcloud-utils', function () {
 
     it('client fails when token expired', function () {
       mock({
-        'test/cf-plugin-config.json': '{ "IamTimeTokenRefreshed": "2021-03-14T12:00:00+01:00", ' +
+        [ibmCloudFunctionsPropsPath]: '{ "IamTimeTokenRefreshed": "2021-03-14T12:00:00+01:00", ' +
             '"WskCliNamespaceId": "some-namespace-id", ' +
             '"WskCliNamespaceMode": "IAM" }',
-        'test/cf-config.json': '{ "IAMToken": "some-token" }'
+        [ibmCloudPropsPath]: '{ "IAMToken": "some-token" }'
       })
 
       assert.throws(() => client(), /IAM token expired/)

--- a/test/ibmcloud-utils.js
+++ b/test/ibmcloud-utils.js
@@ -32,7 +32,7 @@ describe('ibmcloud-utils', function () {
         'test/cf-plugin-config.json': '{ "IamTimeTokenRefreshed": "2021-03-15T13:24:14+01:00" }'
       })
       const timestamp = ibmcloudUtils.getIamTokenTimestamp()
-      assert.strictEqual(timestamp.getTime(), new Date(2021, 2, 15, 13, 24, 14).getTime())
+      assert.strictEqual(timestamp.getTime(), Date.UTC(2021, 2, 15, 12, 24, 14))
     })
 
     it('token not expired', function () {


### PR DESCRIPTION
This will fail deploying when the value of `IamTimeTokenRefreshed` in the functions `config.json` is older than one hour and print instructions for refreshing it by logging in again.