### PR TITLE
Adapt project setup to ibm-functions org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,11 @@ before_install:
   - ./travis/scancode.sh
 before_script:
   - ./travis/setup.sh
+deploy:
+  provider: npm
+  email: reggeenr@de.ibm.com
+  api_key:
+    secure: lyftFmbsZ0S/kcAjf5nVR1W+a1IrtsSghQ7o9w6A7COTKNwBh1QNnF+yh8OL72Sc4/PgRiV4Z6Jg9ZFCt3bWd3tsRcXqTXXspFC/lHsj//0s6M+a0c9pFr/uhND0hWXrIkVr0VLXNPp/3LMORS7fzjKktx/yksivBcdGHj4SX4sz3wHI3uq6gfb9OQXWqcs7jBOgMClKFeqOLaDAFJzRf9DZFsV9z5Eq2MwCALaoXZBbbmNcq795fioHKnMLzMVlN16aWsuDyFxGn/LLMdlmgaDLiF0KITtLM1V9XNrEETurLD41TcNChlsBcsHA15Seg9bsiKU7PX7+s+kb55eB3Gg9wJYhXfND5OFh+DL3GT7tLPetXda8sHaCkoEKOEdy30HEqPYZLy7X2fYQj7Ety4sqhe6SRkPFYhuS6+r179B/0Xu+KF17y1VG7CWHwTEKotZOLF4TLOudJ9O7+rUI0xOlNXj7tAURjXY6OJ1DMAefpRcwM5xaC8/3OIimK7Ab3BZn4or1PwpzK5qQDnaI/350IAK9wDkLyyT1OFywq7xNyfgKhv5gIgjoYEBAdwNTjjMcrGaTyFxLSoo3SluXXMYy9H3FXfBwNJfbF8mfHf3K/U1IdjlJ4TxlEPoUvPSv1a5M2oswZwKeRM6Mqmal+P0tAJzOY2rsJxTtpwkeMpk=
+  on:
+    tags: true
+    repo: ibm-functions/composer

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 #
 -->
 
-# Apache OpenWhisk Composer
+# @ibm-functions/composer
 
-[![Travis](https://travis-ci.com/apache/openwhisk-composer.svg?branch=master)](https://travis-ci.com/apache/openwhisk-composer)
+[![Travis](https://travis-ci.org/ibm-functions/composer.svg?branch=master)](https://travis-ci.org/ibm-functions/composer)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Join
 Slack](https://img.shields.io/badge/join-slack-9B69A0.svg)](http://slack.openwhisk.org/)
@@ -47,7 +47,7 @@ This repository includes:
 Composer is distributed as Node.js package. To install this package, use the
 Node Package Manager:
 ```
-npm install -g openwhisk-composer
+npm install -g @ibm-functions/composer
 ```
 We recommend installing the package globally (with `-g` option) if you intend to
 use the `compose` and `deploy` commands to compile and deploy compositions.
@@ -57,7 +57,7 @@ use the `compose` and `deploy` commands to compile and deploy compositions.
 A composition is typically defined by means of a JavaScript expression as
 illustrated in [samples/demo.js](samples/demo.js):
 ```javascript
-const composer = require('openwhisk-composer')
+const composer = require('@ibm-functions/composer')
 
 module.exports = composer.if(
     composer.action('authenticate', { action: function ({ password }) { return { value: password === 'abc123' } } }),
@@ -98,9 +98,9 @@ existing definitions.
 ## Running a composition
 
 The `demo` composition may be invoked like any action, for instance using the
-OpenWhisk CLI:
+[IBM Cloud CLI](https://cloud.ibm.com/docs/cli):
 ```
-wsk action invoke demo -p password passw0rd
+ibmcloud fn action invoke demo -p password passw0rd
 ```
 ```
 ok: invoked /_/demo with id 09ca3c7f8b68489c8a3c7f8b68b89cdc
@@ -108,7 +108,7 @@ ok: invoked /_/demo with id 09ca3c7f8b68489c8a3c7f8b68b89cdc
 The result of this invocation is the result of the last action in the
 composition, in this case the `failure` action since the password in incorrect:
 ```
-wsk activation result 09ca3c7f8b68489c8a3c7f8b68b89cdc
+ibmcloud fn activation result 09ca3c7f8b68489c8a3c7f8b68b89cdc
 ```
 ```json
 {
@@ -119,7 +119,7 @@ wsk activation result 09ca3c7f8b68489c8a3c7f8b68b89cdc
 
 This invocation creates a trace, i.e., a series of activation records:
 ```
-wsk activation list
+ibmcloud fn activation list
 ```
 <pre>
 Datetime            Activation ID                    Kind     Start Duration   Status  Entity
@@ -211,9 +211,8 @@ combinators or the `async` combinator.
 # Installation from Source
 
 To install composer from a source release, download the composer source code
-from the [Apache OpenWhisk
-Downloads](https://openwhisk.apache.org/downloads.html) page, rename the release
-tarball to `openwhisk-composer.tgz` and install it with command:
+from [our GitHub repo](https://github.com/ibm-functions/composer/releases),
+rename the release tarball to `composer.tgz` and install it with command:
 ```shell
-npm install -g openwhisk-composer.tgz
+npm install -g composer.tgz
 ```

--- a/docs/COMBINATORS.md
+++ b/docs/COMBINATORS.md
@@ -544,7 +544,7 @@ belongs to the same package as the composition, without having to specify the
 package name beforehand.
 
 ```javascript
-const composer = require('openwhisk-composer')
+const composer = require('@ibm-functions/composer')
 
 function invoke (actionShortName) {
   return composer.let(

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "license": "Apache-2.0",
-  "name": "openwhisk-composer",
+  "name": "@ibm-functions/composer",
   "version": "0.12.0",
   "description": "Composer is a new programming model for composing cloud functions built on Apache OpenWhisk.",
-  "homepage": "https://github.com/apache/openwhisk-composer",
+  "homepage": "https://github.com/ibm-functions/composer",
   "main": "composer.js",
   "scripts": {
     "test": "standard && mocha"
@@ -17,13 +17,14 @@
     "client.js",
     "composer.js",
     "conductor.js",
-    "fqn.js",
     "docs/*.md",
+    "fqn.js",
+    "ibmcloud-utils.js",
     "samples/"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/apache/openwhisk-composer.git"
+    "url": "https://github.com/ibm-functions/composer.git"
   },
   "keywords": [
     "functions",

--- a/samples/demo.js
+++ b/samples/demo.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const composer = require('openwhisk-composer')
+const composer = require('@ibm-functions/composer')
 
 module.exports = composer.if(
   composer.action('authenticate', { action: function ({ password }) { return { value: password === 'abc123' } } }),

--- a/samples/retry.js
+++ b/samples/retry.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const composer = require('openwhisk-composer')
+const composer = require('@ibm-functions/composer')
 
 function generateEvenNumber (args) {
   const number = Math.floor(Math.random() * 10)


### PR DESCRIPTION
This PR adds npm deploy settings to the Travis config and updates all references of the `apache/openwhisk-composer` repo/package to `ibm-functions/composer`.