### PR TITLE
Bump Ansible version

### DIFF
--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -35,7 +35,7 @@ cd $ROOTDIR
 git clone --depth=1 https://github.com/apache/openwhisk.git openwhisk
 
 # Install Ansible
-pip install --user ansible==2.5.2
+pip install --user ansible==2.8.19
 
 # Configure runtimes
 cp $SCRIPTDIR/runtimes.json $WHISKDIR/ansible/files


### PR DESCRIPTION
This increases the Ansible version during Travis builds.

Currently, the [build](https://travis-ci.org/github/ibm-functions/composer/builds/763614284#L411) fails because of a syntax error in an unused variable (see https://github.com/apache/openwhisk/blob/master/ansible/group_vars/all#L456), which is not a problem since Ansible 2.6, where unused variables are not templated.